### PR TITLE
Fix issue when document.activeElement is null.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,8 +140,8 @@ const filteringElement = (pKey) => {
   const elementSeparate = checkElementType()
   const elementTypeAvoid = elementSeparate.avoidedTypes
   const elementClassAvoid = elementSeparate.avoidedClasses
-  const filterTypeAvoid = elementTypeAvoid.find(r => r === document.activeElement.tagName.toLowerCase())
-  const filterClassAvoid = elementClassAvoid.find(r => r === '.' + document.activeElement.className.toLowerCase())
+  const filterTypeAvoid = elementTypeAvoid.find(r => r === document.activeElement && document.activeElement.tagName.toLowerCase())
+  const filterClassAvoid = elementClassAvoid.find(r => r === '.' + document.activeElement && document.activeElement.className.toLowerCase())
   return !objectAvoid && mapFunctions[decodedKey] && !filterTypeAvoid && !filterClassAvoid
 }
 


### PR DESCRIPTION
`document.activeElement` can be null, so I added a small check to not trigger an error.