### PR TITLE
Fix filtering of prevented elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,8 +164,8 @@ const filteringElement = (pKey) => {
   const elementSeparate = checkElementType()
   const elementTypeAvoid = elementSeparate.avoidedTypes
   const elementClassAvoid = elementSeparate.avoidedClasses
-  const filterTypeAvoid = elementTypeAvoid.find(r => r === document.activeElement && document.activeElement.tagName.toLowerCase())
-  const filterClassAvoid = elementClassAvoid.find(r => r === '.' + document.activeElement && document.activeElement.className.toLowerCase())
+  const filterTypeAvoid = elementTypeAvoid.find(r => document.activeElement && r === document.activeElement.tagName.toLowerCase())
+  const filterClassAvoid = elementClassAvoid.find(r => document.activeElement && r === '.' + document.activeElement.className.toLowerCase())
   return !objectAvoid && mapFunctions[decodedKey] && !filterTypeAvoid && !filterClassAvoid
 }
 


### PR DESCRIPTION
The old syntax did not work for me since `elementTypeAvoid.find` would always return undefined even though the active element was an `input` and `elementTypeAvoid` contained `"input"`.