### PR TITLE
Publish npm package only when there is a new tag.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ dependencies:
 
 deployment:
   production:
+    tag: /(v)?[0-9]+(\.[0-9]+)*/
     branch: master
     commands:
       - npm publish


### PR DESCRIPTION
So the build will not fail when we are pushing a new commit on the master branch.

Also, it make mandatory to push a new tag to release.