### PR TITLE
allows using selectors in prevent list

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-register": "^6.24.1",
     "chai": "^4.0.2",
     "cross-env": "^3.0.0",
+    "element-matches": "^0.1.2",
     "karma": "^1.7.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import 'element-matches';
+
 let ShortKey = {}
 let mapFunctions = {}
 let objAvoided = []
@@ -159,30 +161,10 @@ const mappingFunctions = ({b, push, once, focus, el}) => {
 const filteringElement = (pKey) => {
   const decodedKey = ShortKey.decodeKey(pKey)
   const objectAvoid = objAvoided.find(r => r === document.activeElement)
-  const elementSeparate = checkElementType()
-  const elementTypeAvoid = elementSeparate.avoidedTypes
-  const elementClassAvoid = elementSeparate.avoidedClasses
-  const filterTypeAvoid = elementTypeAvoid.find(r => document.activeElement && r === document.activeElement.tagName.toLowerCase())
-  const filterClassAvoid = elementClassAvoid.find(r => document.activeElement && r === '.' + document.activeElement.className.toLowerCase())
-  return !objectAvoid && mapFunctions[decodedKey] && !filterTypeAvoid && !filterClassAvoid
-}
 
-const checkElementType = () => {
-  let elmTypeAvoid = []
-  let elmClassAvoid = []
-  elementAvoided.forEach(r => {
-    const dotPosition = r.indexOf('.')
-    if (dotPosition === 0) {
-      elmClassAvoid.push(r)
-    } else if (dotPosition > 0) {
-      elmTypeAvoid.push(r.split('.')[0])
-      elmClassAvoid.push('.' + r.split('.')[1])
-    } else {
-      elmTypeAvoid.push(r)
-    }
-  })
-
-  return {avoidedTypes: elmTypeAvoid, avoidedClasses: elmClassAvoid}
+  // check if the element gets matched by at least one selector in the prevent list
+  const filterAvoid = elementAvoided.find(selector => document.activeElement && document.activeElement.matches(selector))
+  return !objectAvoid && mapFunctions[decodedKey] && !filterAvoid
 }
 
 if (typeof module != 'undefined' && module.exports) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -233,7 +233,7 @@ describe('functionnal tests', () => {
     })
 
     it('does trigger events when only the parent element gets matched by one item in the prevent list', () => {
-      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']" class="disableshortkey"><input></input></div>')
+      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']" class="disableshortkey"><input type="text" /></div>')
       vm.$mount(createDiv())
 
       const input = vm.$el.querySelector('input')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ import Shortkey from '../src/index.js'
 
 find.shim()
 
-Vue.use(Shortkey)
+Vue.use(Shortkey, { prevent: ['.disableshortkey', '.disableshortkey textarea'] })
 const VM = template => new Vue({
   template,
   data() {
@@ -169,6 +169,86 @@ describe('functionnal tests', () => {
       document.dispatchEvent(keyup)
 
       expect(vm.called).to.be.false
+      vm.$destroy()
+    })
+
+    it('does not trigger events when its class is in the prevent list', () => {
+      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']"><textarea class="disableshortkey"></textarea></div>')
+      vm.$mount(createDiv())
+
+      const textarea = vm.$el.querySelector('textarea')
+      textarea.focus()
+      expect(document.activeElement == textarea).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'b'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'b'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.false
+      vm.$destroy()
+    })
+
+    it('does not trigger events when one of its classes is in the prevent list', () => {
+      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']"><textarea class="disableshortkey stylingclass"></textarea></div>')
+      vm.$mount(createDiv())
+
+      const textarea = vm.$el.querySelector('textarea')
+      textarea.focus()
+      expect(document.activeElement == textarea).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'b'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'b'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.false
+      vm.$destroy()
+    })
+
+    it('does not trigger events when it gets matched by one item in the prevent list', () => {
+      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']" class="disableshortkey"><textarea class="stylingclass"></textarea></div>')
+      vm.$mount(createDiv())
+
+      const textarea = vm.$el.querySelector('textarea')
+      textarea.focus()
+      expect(document.activeElement == textarea).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'b'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'b'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.false
+      vm.$destroy()
+    })
+
+    it('does trigger events when only the parent element gets matched by one item in the prevent list', () => {
+      const vm = new VM('<div @shortkey="foo" v-shortkey="[\'b\']" class="disableshortkey"><input></input></div>')
+      vm.$mount(createDiv())
+
+      const input = vm.$el.querySelector('input')
+      input.focus()
+      expect(document.activeElement == input).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'b'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'b'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.true
       vm.$destroy()
     })
 


### PR DESCRIPTION
In other words: Prevents firing of events if the focused element gets matched by at least one selector in the prevent list.

This allows to match form elements for which you are not able to alter the class attribute (eg. in an imported library component).

`Vue.use(Shortkey, { prevent: ['.disableshortkey', '.disableshortkey textarea'] })`
prevents firing events when textarea is focused in the following cases:
```html
<div @shortkey="foo" v-shortkey="['b']"><textarea class="disableshortkey"></textarea></div>
<div @shortkey="foo" v-shortkey="['b']"><textarea class="disableshortkey stylingclass"></textarea></div>
<div @shortkey="foo" v-shortkey="['b']" class="disableshortkey"><textarea class="stylingclass"></textarea></div>
```
but not for
```html
<div @shortkey="foo" v-shortkey="['b']" class="disableshortkey"><input type="text" /></div>
```
since it's an input tag.

the new dev-dependency is only to support IE and a few more old browser versions:
see https://www.npmjs.com/package/element-matches and https://github.com/jelmerdemaat/element-matches/blob/master/index.js