### PR TITLE
Added a `propagate` modifier to let other listeners catch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The function in the modifier __@shortkey__ will be called repeatedly while the k
 <button v-shortkey.once="['ctrl', 'alt', 'o']" @shortkey="theAction()">Open</button>
 ```
 
-
 #### Multi keys
 ```html
 <button v-shortkey="{up: ['arrowup'], down: ['arrowdown']}" @shortkey="theAction">Joystick</button>
@@ -67,6 +66,13 @@ The example below shows how to do this
 Use the modifier `native` to catch the event.
 ```html
  <my-component v-shortkey="['ctrl', 'alt', 'o']" @shortkey.native="theAction()"></my-component>
+```
+
+#### Multiple listeners
+Use the modifier `propagate` to let the event propagate to other listeners
+```html
+ <my-component v-shortkey="['ctrl', 'alt', 'o']" @shortkey.propagate="anAction()"></my-component>
+ <my-component v-shortkey="['ctrl', 'alt', 'o']" @shortkey.propagate="aDifferentAction()"></my-component>
 ```
 
 #### Key list

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -275,6 +275,82 @@ describe('functionnal tests', () => {
     })
   })
 
+  describe('Dispatch triggered event', () => {
+
+    it('trigger listen for keydown and propagte event to all listeners when modifier is present', () => {
+      const vm = new VM(`<div>
+        <button type="button" class="foo" @shortkey="foo" v-shortkey.propagte="[\'c\']">FOO</button>
+        <button type="button" class="bar" @shortkey="bar" v-shortkey.propagte="[\'c\']">BAR</button>
+      </div>`)
+      vm.$mount(createDiv())
+
+      const buttonFoo = vm.$el.querySelector('button.foo')
+      buttonFoo.focus()
+      expect(document.activeElement == buttonFoo).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'c'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'c'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.true
+      //expect(vm.calledBubble).to.be.true
+      vm.$destroy()
+    })
+
+    it('trigger listen for keydown and propagte event to all listeners when modifier is present on the first element', () => {
+      const vm = new VM(`<div>
+        <button type="button" class="foo" @shortkey="foo" v-shortkey.propagte="[\'c\']">FOO</button>
+        <button type="button" class="bar" @shortkey="bar" v-shortkey="[\'c\']">BAR</button>
+      </div>`)
+      vm.$mount(createDiv())
+
+      const buttonFoo = vm.$el.querySelector('button.foo')
+      buttonFoo.focus()
+      expect(document.activeElement == buttonFoo).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'c'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'c'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.true
+      //expect(vm.calledBubble).to.be.true
+      vm.$destroy()
+    })
+
+    it('trigger listen for keydown and propagte event to all listeners when modifier is present on the last element', () => {
+      const vm = new VM(`<div>
+        <button type="button" class="foo" @shortkey="foo" v-shortkey="[\'c\']">FOO</button>
+        <button type="button" class="bar" @shortkey="bar" v-shortkey.propagte="[\'c\']">BAR</button>
+      </div>`)
+      vm.$mount(createDiv())
+
+      const buttonFoo = vm.$el.querySelector('button.foo')
+      buttonFoo.focus()
+      expect(document.activeElement == buttonFoo).to.be.true
+
+      const keydown = createEvent('keydown')
+      keydown.key = 'c'
+      document.dispatchEvent(keydown)
+
+      const keyup = createEvent('keyup')
+      keyup.key = 'c'
+      document.dispatchEvent(keyup)
+
+      expect(vm.called).to.be.true
+      //expect(vm.calledBubble).to.be.true
+      vm.$destroy()
+    })
+
+  })
+
   it('Setting focus with .focus modifier', () => {
     const vm = new VM(`<div><input type="text" /> <button type="button" v-shortkey.focus="['f']">BUTTON</button></div>`)
     vm.$mount(createDiv())


### PR DESCRIPTION
This modifier allows several listeners to catch the same event.

It might solve issue https://github.com/iFgR/vue-shortkey/issues/78 as it gives a neat way to bind the same key on different elements. This will work:

```html
 <my-component v-shortkey="['ctrl', 'alt', 'o']" @shortkey.propagate="anAction()"></my-component>
 <my-component v-shortkey="['ctrl', 'alt', 'o']" @shortkey.propagate="aDifferentAction()"></my-component>
```

I added a few tests for edge cases.

Thanks a heap :v: 

