### PR TITLE
Add ability to add gmail-like shortkey combinations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ const createShortcutIndex = (pKey) => {
   let k = ''
   if (definedCharKeys.length) { 
      definedCharKeys.forEach((keySequence) => {
-        if (keySequence.base === pKey.key && !pKey.shiftKey && !pKey.ctrlKey && !pKey.metaKey && !pKey.altKey ) { // Check if user pressed the 'base'key while NOT holding any modifier
+        if (keySequence.base === pKey.key && !pKey.shiftKey && !pKey.ctrlKey && !pKey.metaKey && !pKey.altKey ) {
           charKeyPressed = pKey.key
          }
     })

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ const createShortcutIndex = (pKey) => {
         k = keySequence.base + keySequence.action
       }
    })
- } else if (( !charKeyPressed && pKey.key && pKey.key !== ' ' && pKey.key.length === 1) || /F\d{1,2}|\//g.test(pKey.key)) {
+ } else if (( !charKeyPressed && pKey.key && pKey.key !== " " && pKey.key.length === 1) || /F\d{1,2}|\//g.test(pKey.key)) {
     k += pKey.key.toLowerCase()
   }
   return k


### PR DESCRIPTION
As requested in #109, this adds the ability to add two-character/ character-number combinations such as `['g', 'h ]` or `['h', 1]`.